### PR TITLE
feat(observability): Add Alertmanager Discord notifications

### DIFF
--- a/kubernetes/apps/observability/alertmanager-discord/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/alertmanager-discord/app/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: alertmanager-discord
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: alertmanager-discord-secret
+    template:
+      data:
+        DISCORD_WEBHOOK: "{{ .ALERTMANAGER_DISCORD_WEBHOOK }}"
+  dataFrom:
+    - extract:
+        key: alertmanager

--- a/kubernetes/apps/observability/alertmanager-discord/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/alertmanager-discord/app/helmrelease.yaml
@@ -1,0 +1,52 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: alertmanager-discord
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  values:
+    controllers:
+      alertmanager-discord:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: rogerrum/alertmanager-discord
+              tag: 1.0.7@sha256:bb4bcb893dacca8735bd634b0796f0a1b3ef05e641f8a7b4921f7d0e5a17ee3e
+            env:
+              DISCORD_AVATAR_URL: https://avatars3.githubusercontent.com/u/3380462
+              DISCORD_USERNAME: Alertmanager
+            envFrom:
+              - secretRef:
+                  name: alertmanager-discord-secret
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 5
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 64Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+    service:
+      app:
+        controller: alertmanager-discord
+        ports:
+          http:
+            port: 9094

--- a/kubernetes/apps/observability/alertmanager-discord/app/kustomization.yaml
+++ b/kubernetes/apps/observability/alertmanager-discord/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/observability/alertmanager-discord/ks.yaml
+++ b/kubernetes/apps/observability/alertmanager-discord/ks.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: alertmanager-discord
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/observability/alertmanager-discord/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: observability
+  wait: false

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
@@ -9,7 +9,7 @@ spec:
     groupBy: ["alertname", "job"]
     groupInterval: 10m
     groupWait: 1m
-    receiver: pushover
+    receiver: discord
     repeatInterval: 12h
     routes:
       - receiver: "null"
@@ -24,11 +24,6 @@ spec:
         matchers:
           - name: alertname
             value: Watchdog
-            matchType: =
-      - receiver: pushover
-        matchers:
-          - name: severity
-            value: critical
             matchType: =
   inhibitRules:
     - equal: ["alertname", "namespace"]
@@ -47,40 +42,7 @@ spec:
         - urlSecret:
             name: &secret alertmanager-secret
             key: ALERTMANAGER_HEARTBEAT_URL
-    - name: pushover
-      pushoverConfigs:
-        - html: true
-          message: |-
-            {{- range .Alerts }}
-              {{- if ne .Annotations.description "" }}
-                {{ .Annotations.description }}
-              {{- else if ne .Annotations.summary "" }}
-                {{ .Annotations.summary }}
-              {{- else if ne .Annotations.message "" }}
-                {{ .Annotations.message }}
-              {{- else }}
-                Alert description not available
-              {{- end }}
-              {{- if gt (len .Labels.SortedPairs) 0 }}
-                <small>
-                  {{- range .Labels.SortedPairs }}
-                    <b>{{ .Name }}:</b> {{ .Value }}
-                  {{- end }}
-                </small>
-              {{- end }}
-            {{- end }}
-          priority: |-
-            {{ if eq .Status "firing" }}1{{ else }}0{{ end }}
+    - name: discord
+      webhookConfigs:
+        - url: http://alertmanager-discord.observability.svc.cluster.local:9094
           sendResolved: true
-          sound: gamelan
-          title: >-
-            [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}]
-            {{ .CommonLabels.alertname }}
-          ttl: 86400s
-          token:
-            name: *secret
-            key: ALERTMANAGER_PUSHOVER_TOKEN
-          userKey:
-            name: *secret
-            key: PUSHOVER_USER_KEY
-          urlTitle: View in Alertmanager

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -7,6 +7,7 @@ components:
   - ../../components/common
   - ../../components/repos/app-template
 resources:
+  - ./alertmanager-discord/ks.yaml
   - ./fluent-bit/ks.yaml
   - ./gatus/ks.yaml
   - ./grafana/ks.yaml


### PR DESCRIPTION
## Summary
Route Alertmanager alerts to Discord instead of Pushover.

## Changes
- **New app:** `alertmanager-discord` - translates Alertmanager webhooks to Discord embeds
- **Updated:** `alertmanagerconfig.yaml` - routes alerts to the new Discord receiver
- **Updated:** `observability/kustomization.yaml` - includes the new app

## Prerequisites
Make sure your `alertmanager` item in 1Password has the field:
- `ALERTMANAGER_DISCORD_WEBHOOK` → your Discord webhook URL

## How it works
```
Alertmanager → alertmanager-discord (port 9094) → Discord webhook
```

---
*Created by Quill ⚡*