### PR TITLE
feat(games): Add Playit.gg agent for Minecraft tunneling

### DIFF
--- a/kubernetes/apps/games/kustomization.yaml
+++ b/kubernetes/apps/games/kustomization.yaml
@@ -9,4 +9,5 @@ components:
 resources:
   # - ./minecraft/mc-router/ks.yaml
   - ./minecraft/survival/ks.yaml
+  - ./playit/ks.yaml
   - ./romm/ks.yaml

--- a/kubernetes/apps/games/playit/app/externalsecret.yaml
+++ b/kubernetes/apps/games/playit/app/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: playit
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: playit-secret
+    template:
+      data:
+        SECRET_KEY: "{{ .PLAYIT_SECRET_KEY }}"
+  dataFrom:
+    - extract:
+        key: playit

--- a/kubernetes/apps/games/playit/app/helmrelease.yaml
+++ b/kubernetes/apps/games/playit/app/helmrelease.yaml
@@ -1,0 +1,43 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: playit
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  values:
+    controllers:
+      playit:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/playit-cloud/playit-agent
+              tag: 0.15
+            env:
+              SECRET_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: playit-secret
+                    key: SECRET_KEY
+            probes:
+              liveness:
+                enabled: false
+              readiness:
+                enabled: false
+              startup:
+                enabled: false
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 128Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }

--- a/kubernetes/apps/games/playit/app/kustomization.yaml
+++ b/kubernetes/apps/games/playit/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/games/playit/ks.yaml
+++ b/kubernetes/apps/games/playit/ks.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: playit
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/games/playit/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: games
+  wait: false


### PR DESCRIPTION
## Summary
Deploy Playit.gg agent to tunnel Minecraft traffic without port forwarding.

## What this does
- Deploys `playit-agent` container in games namespace
- Connects outbound to Playit.gg servers
- Players connect to a `*.playit.gg` hostname instead of your home IP
- No port forwarding required

## Prerequisites
- 1Password item `playit` with field `PLAYIT_SECRET_KEY` ✓

## After deployment
1. Agent will connect and appear in your Playit.gg dashboard
2. Create a tunnel in Playit.gg:
   - Type: TCP
   - Local address: `minecraft-survival.games.svc.cluster.local`
   - Local port: `25565`
3. Playit assigns you a hostname like `abc123.at.playit.gg:12345`
4. Share that with players

---
*Created by Gilfoyle 🜏*