### PR TITLE
fix(security): Complete Pocket-ID configuration

### DIFF
--- a/kubernetes/apps/security/kustomization.yaml
+++ b/kubernetes/apps/security/kustomization.yaml
@@ -7,5 +7,6 @@ components:
   - ../../components/common
   - ../../components/repos/app-template
 resources:
-  - ./lldap/ks.yaml
   - ./authelia/ks.yaml
+  - ./lldap/ks.yaml
+  - ./pocket-id/ks.yaml

--- a/kubernetes/apps/security/pocket-id/app/externalsecret.yaml
+++ b/kubernetes/apps/security/pocket-id/app/externalsecret.yaml
@@ -14,11 +14,10 @@ spec:
         # App
         ENCRYPTION_KEY: "{{ .POCKETID_ENCRYPTION_KEY }}"
         MAXMIND_LICENSE_KEY: "{{ .MAXMIND_LICENSE_KEY }}"
-        # LDAP
-        LDAP_BASE: "{{ .AD_BASE_DN }}"
-        LDAP_BIND_DN: "{{ .AD_LDAP_USER_DN }}"
-        LDAP_BIND_PASSWORD: "{{ .AD_LDAP_USER_PASSWORD }}"
-        LDAP_USER_SEARCH_FILTER: "{{ .AD_SEARCH_FILTER }}"
+        # LDAP (from lldap 1Password item)
+        LDAP_BASE: "{{ .LLDAP_BASE_DN }}"
+        LDAP_BIND_DN: "{{ .LLDAP_USER_DN }}"
+        LDAP_BIND_PASSWORD: "{{ .LLDAP_LDAP_USER_PASS }}"
         # Database
         DB_CONNECTION_STRING: |-
           postgres://{{ .POCKETID_POSTGRES_USER }}:{{ .POCKETID_POSTGRES_PASSWORD }}@postgres-rw.database.svc.cluster.local/{{ .POCKETID_POSTGRES_DB }}
@@ -30,7 +29,7 @@ spec:
         INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
   dataFrom:
     - extract:
-        key: active-directory
+        key: lldap
     - extract:
         key: cloudnative-pg
     - extract:

--- a/kubernetes/apps/security/pocket-id/app/helmrelease.yaml
+++ b/kubernetes/apps/security/pocket-id/app/helmrelease.yaml
@@ -36,18 +36,19 @@ spec:
               EMAILS_VERIFIED: true
               KEYS_STORAGE: database
               LDAP_ENABLED: true
-              LDAP_URL: ldaps://lldap.security.svc.cluster.local
-              LDAP_SKIP_CERT_VERIFY: true
-              LDAP_USER_GROUP_SEARCH_FILTER: (&(objectClass=group)(cn=ID*))
-              LDAP_ATTRIBUTE_USER_UNIQUE_IDENTIFIER: objectGUID
-              LDAP_ATTRIBUTE_GROUP_UNIQUE_IDENTIFIER: objectGUID
+              LDAP_URL: ldap://lldap.security.svc.cluster.local:389
+              LDAP_SKIP_CERT_VERIFY: false
+              LDAP_USER_SEARCH_FILTER: "(objectClass=person)"
+              LDAP_USER_GROUP_SEARCH_FILTER: "(objectClass=groupOfUniqueNames)"
+              LDAP_ATTRIBUTE_USER_UNIQUE_IDENTIFIER: uid
+              LDAP_ATTRIBUTE_GROUP_UNIQUE_IDENTIFIER: cn
               LDAP_ATTRIBUTE_USER_FIRST_NAME: givenName
               LDAP_ATTRIBUTE_USER_LAST_NAME: sn
-              LDAP_ATTRIBUTE_USER_USERNAME: sAMAccountName
+              LDAP_ATTRIBUTE_USER_USERNAME: uid
               LDAP_ATTRIBUTE_USER_EMAIL: mail
-              LDAP_ATTRIBUTE_GROUP_MEMBER: member
+              LDAP_ATTRIBUTE_GROUP_MEMBER: uniqueMember
               LDAP_ATTRIBUTE_GROUP_NAME: cn
-              LDAP_ADMIN_GROUP_NAME: ID-Admin
+              LDAP_ADMIN_GROUP_NAME: pocket-id-admin
               SMTP_FROM: pocket-id@${SECRET_DOMAIN}
               SESSION_DURATION: 43800
               TRUST_PROXY: true
@@ -95,7 +96,7 @@ spec:
           - "id.${SECRET_DOMAIN}"
         parentRefs:
           - name: envoy-external
-            namespace: networking
+            namespace: network
     persistence:
       data:
         enabled: true

--- a/kubernetes/apps/security/pocket-id/app/kustomization.yaml
+++ b/kubernetes/apps/security/pocket-id/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/security/pocket-id/ks.yaml
+++ b/kubernetes/apps/security/pocket-id/ks.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: pocket-id
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/security/pocket-id/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: security
+  wait: false


### PR DESCRIPTION
## Summary
Fixes the empty/misconfigured Pocket-ID files so it can actually deploy.

## Changes
- **ks.yaml** — was empty, now has proper Flux Kustomization
- **kustomization.yaml** — was empty, now references resources
- **helmrelease.yaml** — fixed LDAP config for lldap (was AD attributes), fixed namespace `networking` → `network`
- **externalsecret.yaml** — use `lldap` 1Password item instead of `active-directory`
- **ocirepository.yaml** — deleted (not needed, uses shared app-template)
- **security/kustomization.yaml** — added pocket-id to resources

## 1Password Requirements

Before merging, add these fields to your 1Password items:

### `lldap` item (add field):
- `LLDAP_BASE_DN` — e.g., `dc=phekno,dc=io`

### `pocket-id` item (create new):
- `POCKETID_ENCRYPTION_KEY` — generate: `openssl rand -hex 32`
- `POCKETID_POSTGRES_USER` — e.g., `pocket-id`
- `POCKETID_POSTGRES_PASSWORD` — generate a password
- `POCKETID_POSTGRES_DB` — e.g., `pocket-id`

### `maxmind` item (if you want GeoIP):
- `MAXMIND_LICENSE_KEY` — from maxmind.com (free account)

## Post-deploy
1. Create `pocket-id-admin` group in lldap
2. Add yourself to that group
3. Access https://id.phekno.io

---
*Created by Gilfoyle 🜏*