### PR TITLE
fix(security): correct postgres namespace (database -> db)

### DIFF
--- a/kubernetes/apps/security/pocket-id/app/externalsecret.yaml
+++ b/kubernetes/apps/security/pocket-id/app/externalsecret.yaml
@@ -20,10 +20,10 @@ spec:
         LDAP_BIND_PASSWORD: "{{ .LLDAP_LDAP_USER_PASS }}"
         # Database
         DB_CONNECTION_STRING: |-
-          postgres://{{ .POCKETID_POSTGRES_USER }}:{{ .POCKETID_POSTGRES_PASSWORD }}@postgres-rw.database.svc.cluster.local/{{ .POCKETID_POSTGRES_DB }}
+          postgres://{{ .POCKETID_POSTGRES_USER }}:{{ .POCKETID_POSTGRES_PASSWORD }}@postgres-rw.db.svc.cluster.local/{{ .POCKETID_POSTGRES_DB }}
         # Postgres Init
         INIT_POSTGRES_DBNAME: "{{ .POCKETID_POSTGRES_DB }}"
-        INIT_POSTGRES_HOST: "postgres-rw.database.svc.cluster.local"
+        INIT_POSTGRES_HOST: "postgres-rw.db.svc.cluster.local"
         INIT_POSTGRES_USER: "{{ .POCKETID_POSTGRES_USER }}"
         INIT_POSTGRES_PASS: "{{ .POCKETID_POSTGRES_PASSWORD }}"
         INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"


### PR DESCRIPTION
Init container can't reach postgres because namespace was wrong.

`postgres-rw.database.svc.cluster.local` → `postgres-rw.db.svc.cluster.local`

---
*Gilfoyle 🜏*