### PR TITLE
feat(helm)!: upgrade app-template to 5.0.0

### DIFF
--- a/kubernetes/apps/db/dragonfly/app/helmrelease.yaml
+++ b/kubernetes/apps/db/dragonfly/app/helmrelease.yaml
@@ -92,5 +92,7 @@ spec:
             path: /metrics
             interval: 1m
             scrapeTimeout: 10s
+    defaultPodOptions:
+      automountServiceAccountToken: true
     serviceAccount:
       dragonfly-operator: {}

--- a/kubernetes/apps/observability/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus/app/helmrelease.yaml
@@ -115,6 +115,8 @@ spec:
             identifier: gatus
           subjects:
             - identifier: gatus
+    defaultPodOptions:
+      automountServiceAccountToken: true
     serviceAccount:
       gatus: {}
     persistence:

--- a/kubernetes/apps/observability/gatus/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/gatus/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/observability/unpoller/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/unpoller/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/components/repos/app-template/ocirepository.yaml
+++ b/kubernetes/components/repos/app-template/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
+    tag: 5.0.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template


### PR DESCRIPTION
## Summary

Upgrades bjw-s app-template from 4.6.2 → 5.0.0 across the cluster.

## Breaking Changes (from [upgrade guide](https://bjw-s-labs.github.io/helm-charts/docs/app-template/upgrades/4-to-5/))

| Change | Impact | Action |
|--------|--------|--------|
| `automountServiceAccountToken` defaults to `false` | Apps needing k8s API access will break | Added explicit `true` for dragonfly-operator and gatus |
| Default ServiceAccount created per release | New SA per app, better isolation | No action needed — improves security |
| `rawResources` requires `manifest` wrapper | N/A | We don't use rawResources |
| `jobLabel` defaults to `app.kubernetes.io/name` | ServiceMonitor labels change slightly | Cosmetic, Prometheus will pick up new label |

## Changes

- **3 OCI repos** bumped: shared app-template, gatus, unpoller
- **dragonfly-operator**: added `defaultPodOptions.automountServiceAccountToken: true` (k8s operator, needs API access)
- **gatus**: added `defaultPodOptions.automountServiceAccountToken: true` (watches Services + HTTPRoutes via RBAC)
- **All other 22 apps**: no changes needed — they don't talk to the k8s API

## Rollback

If anything breaks, revert the OCI repo tags back to `4.6.2`. The automountServiceAccountToken additions are harmless on 4.x.

## Testing

After merge, monitor Flux reconciliation:
```bash
KUBECONFIG=~/personal/home-ops/kubeconfig kubectl get helmreleases -A --watch
```

Releases using the shared OCI repo will reconcile first. Gatus and unpoller (local OCI repos) will follow.