### PR TITLE
feat: add whisparr + plex-adult instances

### DIFF
--- a/kubernetes/apps/downloads/kustomization.yaml
+++ b/kubernetes/apps/downloads/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
   - ./recyclarr/ks.yaml
   - ./sabnzbd/ks.yaml
   - ./sonarr/ks.yaml
+  - ./whisparr/ks.yaml

--- a/kubernetes/apps/downloads/whisparr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/whisparr/app/helmrelease.yaml
@@ -1,0 +1,90 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app whisparr
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    controllers:
+      whisparr:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/hotio/whisparr
+              tag: v2
+            env:
+              TZ: "America/Chicago"
+              PUID: "1000"
+              PGID: "1000"
+              UMASK: "002"
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /ping
+                    port: &port 6969
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 3
+              readiness: *probes
+            resources:
+              requests:
+                cpu: 10m
+                memory: 256Mi
+              limits:
+                memory: 2Gi
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.phekno.io"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+    persistence:
+      config:
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        size: 5Gi
+        accessMode: ReadWriteOnce
+      media:
+        type: nfs
+        server: 10.100.50.10
+        path: /tank/video/adult
+        globalMounts:
+          - path: /media
+      downloads:
+        type: nfs
+        server: 10.100.50.10
+        path: /tank/nzbget_downloads
+        globalMounts:
+          - path: /downloads

--- a/kubernetes/apps/downloads/whisparr/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/whisparr/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: downloads
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/downloads/whisparr/ks.yaml
+++ b/kubernetes/apps/downloads/whisparr/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app whisparr
+  namespace: &namespace downloads
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: longhorn
+      namespace: longhorn-system
+  interval: 1h
+  path: ./kubernetes/apps/downloads/whisparr/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ./jellyseerr/ks.yaml
   - ./photoview/ks.yaml
   - ./plex/ks.yaml
+  - ./plex-adult/ks.yaml
   - ./watchstate/ks.yaml
 components:
   - ../../components/common

--- a/kubernetes/apps/media/plex-adult/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex-adult/app/helmrelease.yaml
@@ -1,0 +1,110 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app plex-adult
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      plex-adult:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/home-operations/plex
+              tag: 1.43.1.10611@sha256:a9c3723cb31cc9621df27cf5801184c290293adf1df2bfaea4b8b6fc01dbfd96
+            env:
+              TZ: America/Chicago
+              PLEX_ADVERTISE_URL: https://plex-adult.phekno.io:443
+              PLEX_NO_AUTH_NETWORKS: 10.0.0.0/8
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /identity
+                    port: &port 32400
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 100m
+              limits:
+                memory: 8Gi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        supplementalGroups: [44]
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.phekno.io"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+    persistence:
+      config:
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        size: 10Gi
+        accessMode: ReadWriteOnce
+        globalMounts:
+          - path: /config/Library/Application Support/Plex Media Server
+      config-cache:
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        size: 5Gi
+        accessMode: ReadWriteOnce
+        globalMounts:
+          - path: /config/Library/Application Support/Plex Media Server/Cache
+      config-logs:
+        type: emptyDir
+        globalMounts:
+          - path: /config/Library/Application Support/Plex Media Server/Logs
+      transcode:
+        type: emptyDir
+      media:
+        type: nfs
+        server: 10.100.50.10
+        path: /tank/video/adult
+        globalMounts:
+          - path: /media
+            readOnly: true
+      tmp:
+        type: emptyDir

--- a/kubernetes/apps/media/plex-adult/app/kustomization.yaml
+++ b/kubernetes/apps/media/plex-adult/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: media
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/media/plex-adult/ks.yaml
+++ b/kubernetes/apps/media/plex-adult/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app plex-adult
+  namespace: &namespace media
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: longhorn
+      namespace: longhorn-system
+  interval: 1h
+  path: ./kubernetes/apps/media/plex-adult/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
## Summary

Adds a dedicated adult media pipeline: Whisparr for collection management and a separate Plex instance for library isolation.

## New Services

### Whisparr (`downloads` namespace)
- **Image:** `ghcr.io/hotio/whisparr:v2`
- **Port:** 6969
- **Route:** `whisparr.phekno.io` (internal)
- **Storage:** 5Gi Longhorn PVC (config) + NFS media (`/tank/video/adult`) + NFS downloads
- **Purpose:** Adult movie collection manager, integrates with Prowlarr + Sabnzbd

### Plex Adult (`media` namespace)
- **Image:** Same as main Plex (`ghcr.io/home-operations/plex:1.43.1.10611`)
- **Port:** 32400
- **Route:** `plex-adult.phekno.io` (internal)
- **Storage:** 10Gi config + 5Gi cache (Longhorn) + NFS media (`/tank/video/adult`, read-only)
- **Purpose:** Isolated Plex server for adult library — separate server identity, sharing controls, and watch history

## Prerequisites Before Merge

- [ ] Create `/tank/video/adult` directory on Proxmox NFS export (`10.100.50.10`)
- [ ] Claim a new Plex server token for the adult instance (first-run setup)
- [ ] Add Whisparr as an app in Prowlarr (Settings → Apps)
- [ ] Add `adult` category to Sabnzbd (Config → Categories) pointing to the right download path

## Shared Infrastructure (no changes needed)

- **Sabnzbd** — shared download client, just needs a new category
- **Prowlarr** — shared indexer manager, just needs Whisparr added as an app + adult indexers
- **Envoy Gateway** — routes handled via standard HTTPRoute pattern

## Notes

- Both services use the same NFS path (`/tank/video/adult`) — Whisparr writes, Plex reads
- Plex-adult has no LoadBalancer/external route (internal only via envoy-internal)
- Memory limits are conservative (2Gi whisparr, 8Gi plex-adult) — can adjust after observing usage