### PR TITLE
fix(plex): bind plex-config PVC to restored volume

### DIFF
--- a/kubernetes/apps/media/plex/app/kustomization.yaml
+++ b/kubernetes/apps/media/plex/app/kustomization.yaml
@@ -4,7 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
-  - ./pvc.yaml
+  - ./pv-config.yaml
   - ./pvc-config.yaml
 # configMapGenerator:
 #   - name: plex-loki-rules

--- a/kubernetes/apps/media/plex/app/pv-config.yaml
+++ b/kubernetes/apps/media/plex/app/pv-config.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: plex-config-restore-pv
+spec:
+  capacity:
+    storage: 50Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: longhorn
+  claimRef:
+    namespace: media
+    name: plex-config
+  csi:
+    driver: driver.longhorn.io
+    fsType: ext4
+    volumeHandle: plex-config-restore
+    volumeAttributes:
+      staleReplicaTimeout: "30"

--- a/kubernetes/apps/media/plex/app/pvc-config.yaml
+++ b/kubernetes/apps/media/plex/app/pvc-config.yaml
@@ -11,3 +11,4 @@ spec:
     requests:
       storage: 50Gi
   storageClassName: longhorn
+  volumeName: plex-config-restore-pv


### PR DESCRIPTION
## Context

The previous PR (#642) inadvertently caused Helm to delete the original `plex-config` PVC when switching from inline PVC to `existingClaim`. The volume was restored from the S3 backup (midnight today).

## Changes

- Add static PV manifest (`pv-config.yaml`) pointing to `plex-config-restore` Longhorn volume
- Update PVC manifest to bind to the static PV via `volumeName`
- Remove unused `pvc.yaml` reference (created orphaned `plex-cache` PVC)

## Manual cleanup needed after merge

```bash
# Delete the orphaned plex-cache PVC (5Gi, unused)
kubectl delete pvc plex-cache -n media
```

Plex is already running on the restored volume.