### PR TITLE
feat(snmp-exporter): add UPS monitoring via SNMPv3

### DIFF
--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ./gatus/ks.yaml
   - ./grafana/ks.yaml
   - ./kube-prometheus-stack/ks.yaml
+  - ./snmp-exporter/ks.yaml
   - ./tautulli/ks.yaml
   - ./unpoller/ks.yaml
   - ./victoria-logs/ks.yaml

--- a/kubernetes/apps/observability/snmp-exporter/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/externalsecret.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: snmp-exporter
+  namespace: observability
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: snmp-exporter-secret
+    template:
+      data:
+        snmp.yml: |
+          auths:
+            cyberpower_v3:
+              version: 3
+              security_level: authPriv
+              username: "{{ .SNMP_USERNAME }}"
+              password: "{{ .AUTH_PASSWORD }}"
+              auth_protocol: "{{ .AUTH_PROTOCOL }}"
+              priv_protocol: "{{ .PRIVACY_PROTOCOL }}"
+              priv_password: "{{ .PRIVACY_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: ups

--- a/kubernetes/apps/observability/snmp-exporter/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/grafanadashboard.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: cyberpower-ups
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+  url: https://grafana.com/api/dashboards/21605/revisions/2/download
+  folder: power

--- a/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
@@ -1,0 +1,64 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: snmp-exporter
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  values:
+    controllers:
+      snmp-exporter:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: prom/snmp-exporter
+              tag: v0.26.0
+            args:
+              - --config.file=/etc/snmp_exporter/snmp.yml
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: &port 9116
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 128Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+    service:
+      app:
+        controller: snmp-exporter
+        ports:
+          http:
+            port: *port
+    persistence:
+      config:
+        type: secret
+        name: snmp-exporter-secret
+        globalMounts:
+          - path: /etc/snmp_exporter/snmp.yml
+            subPath: snmp.yml
+            readOnly: true

--- a/kubernetes/apps/observability/snmp-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./grafanadashboard.yaml
+  - ./helmrelease.yaml
+  - ./scrapeconfig.yaml

--- a/kubernetes/apps/observability/snmp-exporter/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/scrapeconfig.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/scrapeconfig_v1alpha1.json
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: &name snmp-exporter-cyberpower
+spec:
+  staticConfigs:
+    - targets:
+        - 10.100.1.15
+  metricsPath: /snmp
+  params:
+    module: [cyberpower]
+    auth: [cyberpower_v3]
+  relabelings:
+    - sourceLabels: [__address__]
+      targetLabel: __param_target
+    - sourceLabels: [__param_target]
+      targetLabel: instance
+    - targetLabel: __address__
+      replacement: snmp-exporter.observability.svc.cluster.local:9116
+    - action: replace
+      targetLabel: job
+      replacement: *name
+  scrapeInterval: 60s
+  scrapeTimeout: 30s

--- a/kubernetes/apps/observability/snmp-exporter/ks.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/ks.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: snmp-exporter
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/observability/snmp-exporter/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: observability
+  wait: false


### PR DESCRIPTION
## Summary
- Deploys `prom/snmp-exporter` in the `observability` namespace via the shared `app-template` OCIRepository, with SNMPv3 credentials sourced from 1Password (`ups` item) through ExternalSecret and rendered into the exporter's `snmp.yml`.
- Adds a `ScrapeConfig` targeting the RMCARD205 at `10.100.1.15` using the bundled `cyberpower` module and the `cyberpower_v3` auth block.
- Imports community Grafana dashboard [21605](https://grafana.com/grafana/dashboards/21605-cyberpower-ups-dashboard/) (rev 2) into a new `power` folder.

## Test plan
- [ ] Flux reconciles the new `snmp-exporter` Kustomization
- [ ] `kubectl get externalsecret -n observability snmp-exporter` reports `SecretSynced`
- [ ] `snmp-exporter` pod is `Running` and `Ready`
- [ ] Port-forward and `curl 'http://localhost:9116/snmp?target=10.100.1.15&module=cyberpower&auth=cyberpower_v3'` returns CyberPower metrics
- [ ] Prometheus `Status -> Targets` shows `snmp-exporter-cyberpower` as UP
- [ ] CyberPower UPS dashboard renders in Grafana under the `power` folder with live data

🤖 Generated with [Claude Code](https://claude.com/claude-code)