### PR TITLE
fix(snmp-exporter): preserve bundled modules

### DIFF
--- a/kubernetes/apps/observability/snmp-exporter/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/externalsecret.yaml
@@ -13,7 +13,7 @@ spec:
     name: snmp-exporter-secret
     template:
       data:
-        snmp.yml: |
+        auths.yml: |
           auths:
             cyberpower_v3:
               version: 3

--- a/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
@@ -21,6 +21,7 @@ spec:
               tag: v0.26.0
             args:
               - --config.file=/etc/snmp_exporter/snmp.yml
+              - --config.file=/etc/snmp_exporter/auths.yml
             probes:
               liveness: &probes
                 enabled: true
@@ -55,10 +56,10 @@ spec:
           http:
             port: *port
     persistence:
-      config:
+      auths:
         type: secret
         name: snmp-exporter-secret
         globalMounts:
-          - path: /etc/snmp_exporter/snmp.yml
-            subPath: snmp.yml
+          - path: /etc/snmp_exporter/auths.yml
+            subPath: auths.yml
             readOnly: true


### PR DESCRIPTION
## Summary
Mounting the ExternalSecret-rendered `snmp.yml` at `/etc/snmp_exporter/snmp.yml` clobbered the image's bundled config — which is where the `cyberpower` module (and every other module) is actually defined. Scrapes returned `Unknown module 'cyberpower'`.

snmp_exporter merges configs when `--config.file` is passed multiple times, so this PR:
- Renames the secret key from `snmp.yml` → `auths.yml`
- Mounts it at `/etc/snmp_exporter/auths.yml` (alongside the image's bundled `snmp.yml`, not on top of it)
- Adds a second `--config.file` arg so both files are loaded and merged

## Test plan
Verified in-cluster with a temporary pod using the new layout:
- `Unknown module` error is gone — the exporter accepts `module=cyberpower` and `auth=cyberpower_v3`.
- (UPS is currently not responding to SNMP at all — separate issue with the RMCARD205 ACL/service; not in scope.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)