### PR TITLE
fix(snmp-exporter): switch RMCARD205 scraping to SNMPv1 and bump image

### DIFF
--- a/kubernetes/apps/observability/snmp-exporter/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/externalsecret.yaml
@@ -15,14 +15,9 @@ spec:
       data:
         auths.yml: |
           auths:
-            cyberpower_v3:
-              version: 3
-              security_level: authPriv
-              username: "{{ .SNMP_USERNAME }}"
-              password: "{{ .AUTH_PASSWORD }}"
-              auth_protocol: "{{ .AUTH_PROTOCOL }}"
-              priv_protocol: "{{ .PRIVACY_PROTOCOL }}"
-              priv_password: "{{ .PRIVACY_PASSWORD }}"
+            cyberpower_v1:
+              version: 1
+              community: "{{ .SNMP_COMMUNITY }}"
   dataFrom:
     - extract:
         key: ups

--- a/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           app:
             image:
               repository: prom/snmp-exporter
-              tag: v0.26.0
+              tag: v0.30.1
             args:
               - --config.file=/etc/snmp_exporter/snmp.yml
               - --config.file=/etc/snmp_exporter/auths.yml

--- a/kubernetes/apps/observability/snmp-exporter/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/scrapeconfig.yaml
@@ -11,7 +11,7 @@ spec:
   metricsPath: /snmp
   params:
     module: [cyberpower]
-    auth: [cyberpower_v3]
+    auth: [cyberpower_v1]
   relabelings:
     - sourceLabels: [__address__]
       targetLabel: __param_target


### PR DESCRIPTION
## Summary
Two issues converged to produce zero metrics from the snmp-exporter:

1. **SNMPv3 authPriv via gosnmp silently times out** against the RMCARD205. Engine-ID discovery succeeds but the authenticated request is dropped — same failure mode as [prometheus/snmp_exporter#257](https://github.com/prometheus/snmp_exporter/issues/257) (gosnmp `usmStatsNotInTimeWindows` handling). Net-snmp with identical credentials works fine.
2. **SNMPv2c didn't help either**: snmp_exporter uses `GETBULK` on v2c, and the RMCARD's SNMP stack silently drops GETBULK packets despite advertising v2c support. Net-snmp's `snmpwalk -v 2c` masked this — it defaults to GET-NEXT, not GETBULK. Tcpdump confirmed: v2c GETBULK out → no response; v1 GET-NEXT out → response immediately.

**SNMPv1 (GET-NEXT)** is the only mode the RMCARD reliably answers, so switch the auth accordingly. Image also bumped to `v0.30.1` (current upstream stable; Renovate will track it).

## Prereqs (already done out-of-band)
- RMCARD205: SNMPv1 service enabled, community `prometheus` → Read-Only, NMS IP `0.0.0.0`
- 1Password `ups` item: new field `SNMP_COMMUNITY = prometheus`

## Verification (already run live against the UPS)
- net-snmp `snmpwalk -v 1 -c prometheus` from cluster pod → ✅
- `prom/snmp-exporter:v0.30.1` with `version: 1` + community against the live UPS via the `cyberpower` module → **69 metrics returned**, including `upsBaseIdentModel="PR1500RT2U"`, `upsBaseIdentName="RMCARD205"`, serial number, firmware revisions, etc.

## Test plan post-merge
- [ ] ExternalSecret resyncs (`SecretSynced`)
- [ ] New exporter pod with image `v0.30.1` starts cleanly
- [ ] `kubectl run` curl against `/snmp?target=10.100.1.15&module=cyberpower&auth=cyberpower_v1` returns metrics
- [ ] Prometheus target `snmp-exporter-cyberpower` flips to UP
- [ ] Grafana dashboard 21605 starts showing live data

🤖 Generated with [Claude Code](https://claude.com/claude-code)