### PR TITLE
fix(snmp-exporter): probe /-/healthy (the v0.30+ health endpoint)

### DIFF
--- a/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /health
+                    path: /-/healthy
                     port: &port 9116
                   initialDelaySeconds: 0
                   periodSeconds: 10


### PR DESCRIPTION
## Summary
After bumping `prom/snmp-exporter` from v0.26.0 to v0.30.1, the pod went into CrashLoopBackOff. Cause: the exporter renamed its health endpoint from `/health` (returns 404 on v0.30+) to `/-/healthy`. Liveness and readiness probes were hitting the old path.

Verified against a clean v0.30.1 pod:
- `/health` → 404
- `/-/healthy` → 200 ✅
- `/metrics` → 200
- `/-/ready` → 404 (so we stick with `/-/healthy` for both probes, matching the previous shared-probe shape)

## Test plan
- [ ] New pod starts and stays `Ready`
- [ ] `/snmp?target=10.100.1.15&module=cyberpower&auth=cyberpower_v1` returns metrics through the service
- [ ] Grafana dashboard 21605 populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)