### PR TITLE
fix(snmp-exporter): dashboard polish (model/serial, frequency unit, output panel)

### DIFF
--- a/kubernetes/apps/observability/snmp-exporter/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/grafanadashboard.yaml
@@ -48,15 +48,14 @@ spec:
           "gridPos": {"h": 4, "w": 4, "x": 0, "y": 0},
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
           "targets": [{"expr": "upsBaseIdentModel{instance=~\"$instance\"}", "legendFormat": "{{upsBaseIdentModel}}", "instant": true}],
-          "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "mappings": [{"type": "value", "options": {"1": {"text": "—", "color": "text"}}}]}},
-          "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "/^upsBaseIdentModel$/"}, "textMode": "name", "colorMode": "value"}
+          "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": ""}, "textMode": "name", "colorMode": "none"}
         },
         {
           "id": 2, "type": "stat", "title": "Serial",
           "gridPos": {"h": 4, "w": 5, "x": 4, "y": 0},
           "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
           "targets": [{"expr": "upsAdvanceIdentSerialNumber{instance=~\"$instance\"}", "legendFormat": "{{upsAdvanceIdentSerialNumber}}", "instant": true}],
-          "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "/^upsAdvanceIdentSerialNumber$/"}, "textMode": "name", "colorMode": "none"}
+          "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": ""}, "textMode": "name", "colorMode": "none"}
         },
         {
           "id": 3, "type": "stat", "title": "Battery Status",
@@ -191,7 +190,13 @@ spec:
             {"expr": "upsAdvanceOutputVoltage{instance=~\"$instance\"} / 10", "legendFormat": "Output V"},
             {"expr": "upsAdvanceOutputPower{instance=~\"$instance\"}", "legendFormat": "Output W"}
           ],
-          "fieldConfig": {"defaults": {"unit": "short"}}
+          "fieldConfig": {
+            "defaults": {"unit": "short"},
+            "overrides": [
+              {"matcher": {"id": "byName", "options": "Output V"}, "properties": [{"id": "unit", "value": "volt"}]},
+              {"matcher": {"id": "byName", "options": "Output W"}, "properties": [{"id": "unit", "value": "watt"}]}
+            ]
+          }
         },
         {
           "id": 22, "type": "timeseries", "title": "Battery Voltage",
@@ -208,7 +213,7 @@ spec:
             {"expr": "upsAdvanceInputFrequency{instance=~\"$instance\"} / 10", "legendFormat": "Input"},
             {"expr": "upsAdvanceOutputFrequency{instance=~\"$instance\"} / 10", "legendFormat": "Output"}
           ],
-          "fieldConfig": {"defaults": {"unit": "rotHz"}}
+          "fieldConfig": {"defaults": {"unit": "hertz"}}
         }
       ]
     }


### PR DESCRIPTION
## Summary
Three small fixes from your first look at the dashboard:

- **Model / Serial were blank.** The metric value is just `1` — the string is in a label. My `reduceOptions.fields` filter regex blocked the legend-renamed series. Removed it so `textMode=name` shows the label value.
- **Frequency unit was `rotHz`** (Grafana's revolutions-per-second code). Switched to the correct `hertz` unit code so it renders as "Hz".
- **Output Voltage & Power panel** mashed V and W on a single `short` axis. Added per-series unit overrides (`volt` and `watt`).

## Test plan
- [ ] Model panel shows `PR1500RT2U`
- [ ] Serial panel shows `PY2NT7G00040`
- [ ] Frequency panel shows e.g. `60 Hz`, not `60 rotHz`
- [ ] Output panel renders V series in volts and W series in watts

🤖 Generated with [Claude Code](https://claude.com/claude-code)